### PR TITLE
fix(AutocompleteSuggestCache) Increase AutoField length

### DIFF
--- a/src/DataObjects/AutocompleteSuggestCache.php
+++ b/src/DataObjects/AutocompleteSuggestCache.php
@@ -14,7 +14,7 @@ class AutocompleteSuggestCache extends DataObject
 {
 
     private static $db = [
-        'AutoField' => 'Varchar(33)',
+        'AutoField' => 'Varchar(255)',
         'AutoName' => 'Text',
     ];
     private static $indexes = [


### PR DESCRIPTION
This field gets truncated with namespaced classes meaning the cache never works.